### PR TITLE
Fix iteration range to properly display final output

### DIFF
--- a/clipdraw.ipynb
+++ b/clipdraw.ipynb
@@ -442,7 +442,7 @@
         "color_optim = torch.optim.Adam(color_vars, lr=0.01)\n",
         "\n",
         "# Run the main optimization loop\n",
-        "for t in range(args.num_iter):\n",
+        "for t in range(args.num_iter + 1):\n",
         "\n",
         "    # Anneal learning rate (makes videos look cleaner)\n",
         "    if t == int(args.num_iter * 0.5):\n",


### PR DESCRIPTION
Fixes a bug where, with default `num_iter` value, the program fails to show the result of the final 10 iterations of the drawing.